### PR TITLE
fix spelling of False

### DIFF
--- a/exercise_01.py
+++ b/exercise_01.py
@@ -2,7 +2,7 @@
 first_name = "Andre"  # Vornamen
 last_name = "Zabel"   # Nachnamen
 birth_year = 1971     # Geburtsjahr
-has_license = Fals    # Führerscheinstatus
+has_license = False    # Führerscheinstatus
 
 # Ausgabe der Variablen
 print("Vorname:", first_name)


### PR DESCRIPTION
Da hat ein "e" bei False gefehlt

## Summary by Sourcery

Fix the spelling of the boolean value 'False' in the 'has_license' variable to ensure correct boolean assignment.

Bug Fixes:
- Correct the spelling of the boolean value 'False' in the variable 'has_license'.